### PR TITLE
博客创作类型添加

### DIFF
--- a/blog-service/blog-content-server/src/main/java/cn/sticki/blog/content/pojo/BlogDoc.java
+++ b/blog-service/blog-content-server/src/main/java/cn/sticki/blog/content/pojo/BlogDoc.java
@@ -81,6 +81,12 @@ public class BlogDoc {
 	Integer status;
 
 	/**
+	 * 博客创作类型：1. 原创; 2. 转载
+	 */
+	@Field(type = FieldType.Integer)
+	Integer createType;
+
+	/**
 	 * 由其他属性copy而来，主要用于搜索功能，并非该实体类中的成员
 	 */
 	@JsonIgnore

--- a/blog-service/blog-server/src/main/java/cn/sticki/blog/controller/BlogConsoleController.java
+++ b/blog-service/blog-server/src/main/java/cn/sticki/blog/controller/BlogConsoleController.java
@@ -85,25 +85,15 @@ public class BlogConsoleController {
 	 */
 	@PostMapping("/blog")
 	public RestResult<Object> saveBlog(BlogSaveBO blog, MultipartFile coverImage, @RequestHeader Integer id) {
+
+		// 进入入参校验
+		blog.paramCheck(true);
+
+		// 设置其他参数，保存博客
 		blog.setCoverImageFile(coverImage);
 		blog.setAuthorId(id);
-		// 如果为新增博客，则需要全部参数
-		if (blog.getId() == null && (blog.getContent() == null || blog.getTitle() == null || blog.getDescription() == null || blog.getStatus() == null)) {
-			return new RestResult<>(400, "参数异常");
-		}
-		// 如果是修改博客，则需要有至少一个参数
-		if (blog.getId() != null && blog.getContent() == null && blog.getTitle() == null && blog.getDescription() == null && blog.getStatus() == null) {
-			return new RestResult<>(400, "参数异常");
-		}
-		// html 和 md要不都为null，要不都不为null
-		if ((blog.getContent() == null) != (blog.getContentHtml() == null)) {
-			return new RestResult<>(400, "参数异常");
-		}
-		// 检查封面图
-		if (FileUtils.isNotEmpty(blog.getCoverImageFile())) {
-			FileUtils.checkFile(blog.getCoverImageFile(), 1024 * 1024L, FileType.JPEG, FileType.PNG);
-		}
 		blogService.saveBlog(blog);
+
 		return new RestResult<>();
 	}
 

--- a/blog-service/blog-server/src/main/java/cn/sticki/blog/pojo/bo/BlogSaveBO.java
+++ b/blog-service/blog-server/src/main/java/cn/sticki/blog/pojo/bo/BlogSaveBO.java
@@ -1,9 +1,18 @@
 package cn.sticki.blog.pojo.bo;
 
+import cn.sticki.blog.type.BlogCreateTypeEnum;
+import cn.sticki.blog.type.BlogStatusType;
+import cn.sticki.common.result.RestResult;
+import cn.sticki.resource.type.FileType;
+import cn.sticki.resource.utils.FileUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.Assert;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
 
 /**
  * @author 阿杆
@@ -26,6 +35,7 @@ public class BlogSaveBO {
 	/**
 	 * 标题
 	 */
+	@NotNull("博客标题不能为空")
 	String title;
 
 	/**
@@ -36,6 +46,7 @@ public class BlogSaveBO {
 	/**
 	 * 内容(md格式)
 	 */
+	@NotNull("博客内容不能为空")
 	String content;
 
 	/**
@@ -44,13 +55,50 @@ public class BlogSaveBO {
 	String contentHtml;
 
 	/**
-	 * 博客状态码
+	 * 博客状态码 发表状态（1表示已发表、2表示未发表、3为仅自己可见、4为回收站、5为审核中）
 	 */
+	@NotNull("博客状态码不能为空")
 	Integer status;
 
 	/**
 	 * 封面图
 	 */
 	MultipartFile coverImageFile;
+
+	/**
+	 * 博客创作类型：1. 原创; 2. 转载
+	 */
+	Integer createType;
+
+	/**
+	 * 前端入参校验
+	 *
+	 * @param saveFlag 是保存还是更新  true 保存， false 更新
+	 */
+	public void paramCheck(boolean saveFlag) {
+
+		if (saveFlag) {
+			Assert.isNull(this.id, "保存博客不应该有ID入参");
+		}
+
+		// 状态校验
+		Assert.isTrue(Objects.equals(this.status, BlogStatusType.PUBLISH.getValue())
+						|| Objects.equals(this.status, BlogStatusType.DRAFT.getValue())
+						|| Objects.equals(this.status, BlogStatusType.PERSONAL.getValue())
+				, "博客状态仅可以是草稿或发布状态或仅自己可见");
+
+		// 创作类型校验
+		Assert.isTrue(BlogCreateTypeEnum.getEnum(this.createType).isPresent(), "创作类型值非法");
+
+		// 描述校验
+		if (Objects.equals(this.status, BlogStatusType.PUBLISH.getValue())) {
+			Assert.notNull(description, "发布状态，文章摘要不能为空");
+		}
+
+		// 检查封面图
+		if (FileUtils.isNotEmpty(this.coverImageFile)) {
+			FileUtils.checkFile(this.coverImageFile, 1024 * 1024L, FileType.JPEG, FileType.PNG);
+		}
+	}
 
 }

--- a/blog-service/blog-server/src/main/java/cn/sticki/blog/pojo/domain/Blog.java
+++ b/blog-service/blog-server/src/main/java/cn/sticki/blog/pojo/domain/Blog.java
@@ -62,4 +62,9 @@ public class Blog {
 	 */
 	Integer status;
 
+	/**
+	 * 博客创作类型：1. 原创; 2. 转载
+	 */
+	Integer createType;
+
 }

--- a/blog-service/blog-server/src/main/java/cn/sticki/blog/type/BlogCreateTypeEnum.java
+++ b/blog-service/blog-server/src/main/java/cn/sticki/blog/type/BlogCreateTypeEnum.java
@@ -1,0 +1,56 @@
+package cn.sticki.blog.type;
+
+import lombok.Getter;
+import org.springframework.util.Assert;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Date 2022/10/25
+ *
+ * @author likangli
+ * description 博客创作类型
+ */
+public enum BlogCreateTypeEnum {
+
+	/**
+	 * 博客创作类型枚举
+	 */
+	ORIGINAL(1, "原创"),
+	REPRINT(2, "转载"),
+	;
+
+	/**
+	 * 创作类型编码
+	 */
+	@Getter
+	private final Integer code;
+
+	/**
+	 * 创作编码描述
+	 */
+	@Getter
+	private final String desc;
+
+	BlogCreateTypeEnum(Integer code, String desc) {
+		this.code = code;
+		this.desc = desc;
+	}
+
+	/**
+	 * 根据创建编码获取枚举类
+	 *
+	 * @param code 创作编码
+	 * @return 创作枚举类Optional对象
+	 */
+	public static Optional<BlogCreateTypeEnum> getEnum(Integer code) {
+
+		Assert.notNull(code, "创建类型编码不能为空");
+		return Stream.of(BlogCreateTypeEnum.values())
+				.filter(e -> Objects.equals(e.getCode(), code))
+				.findFirst();
+	}
+
+}

--- a/common/common-web/pom.xml
+++ b/common/common-web/pom.xml
@@ -52,6 +52,10 @@
 			<artifactId>aspectjweaver</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>cn.hutool</groupId>
+			<artifactId>hutool-all</artifactId>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/common/common-web/src/main/java/cn/sticki/common/web/advice/DefaultExceptionAdvice.java
+++ b/common/common-web/src/main/java/cn/sticki/common/web/advice/DefaultExceptionAdvice.java
@@ -69,7 +69,11 @@ public class DefaultExceptionAdvice {
 	@ExceptionHandler({MissingRequestValueException.class, IllegalArgumentException.class, TypeMismatchException.class})
 	public RestResult<Object> doIllegalArgumentException(Exception e) {
 		log.warn("参数异常,{}", e.getMessage());
-		return new RestResult<>(402, "参数异常", null, false);
+		String message = "参数异常";
+		if (e instanceof IllegalArgumentException) {
+			message = "参数异常:" + e.getMessage();
+		}
+		return new RestResult<>(402, message, null, false);
 	}
 
 	@ExceptionHandler(BindException.class)

--- a/common/common-web/src/main/java/cn/sticki/common/web/config/FilterConfig.java
+++ b/common/common-web/src/main/java/cn/sticki/common/web/config/FilterConfig.java
@@ -18,18 +18,18 @@ import java.util.List;
 @Configuration
 public class FilterConfig {
 
-	@Bean
-	public FilterRegistrationBean<XssFilter> xssFilter() {
-
-		FilterRegistrationBean<XssFilter> registrationBean = new FilterRegistrationBean<>();
-		// 配置不走xss过滤器的路径，GET\DELETE请求默认不走
-		List<String> excludes = new ArrayList<>();
-		XssFilter myFilter = new XssFilter(excludes);
-
-		registrationBean.setFilter(myFilter);
-		registrationBean.setUrlPatterns(Collections.singletonList("/*"));
-		registrationBean.setOrder(1);
-		return registrationBean;
-	}
+	// @Bean
+	// public FilterRegistrationBean<XssFilter> xssFilter() {
+	//
+	// 	FilterRegistrationBean<XssFilter> registrationBean = new FilterRegistrationBean<>();
+	// 	// 配置不走xss过滤器的路径，GET\DELETE请求默认不走
+	// 	List<String> excludes = new ArrayList<>();
+	// 	XssFilter myFilter = new XssFilter(excludes);
+	//
+	// 	registrationBean.setFilter(myFilter);
+	// 	registrationBean.setUrlPatterns(Collections.singletonList("/*"));
+	// 	registrationBean.setOrder(1);
+	// 	return registrationBean;
+	// }
 
 }

--- a/common/common-web/src/main/java/cn/sticki/common/web/config/FilterConfig.java
+++ b/common/common-web/src/main/java/cn/sticki/common/web/config/FilterConfig.java
@@ -1,0 +1,35 @@
+package cn.sticki.common.web.config;
+
+import cn.sticki.common.web.filter.XssFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Date 2022/10/26
+ *
+ * @author likangli
+ * description
+ */
+@Configuration
+public class FilterConfig {
+
+	@Bean
+	public FilterRegistrationBean<XssFilter> xssFilter() {
+
+		FilterRegistrationBean<XssFilter> registrationBean = new FilterRegistrationBean<>();
+		// 配置不走xss过滤器的路径，GET\DELETE请求默认不走
+		List<String> excludes = new ArrayList<>();
+		XssFilter myFilter = new XssFilter(excludes);
+
+		registrationBean.setFilter(myFilter);
+		registrationBean.setUrlPatterns(Collections.singletonList("/*"));
+		registrationBean.setOrder(1);
+		return registrationBean;
+	}
+
+}

--- a/common/common-web/src/main/java/cn/sticki/common/web/filter/XssFilter.java
+++ b/common/common-web/src/main/java/cn/sticki/common/web/filter/XssFilter.java
@@ -1,0 +1,61 @@
+package cn.sticki.common.web.filter;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.util.CollectionUtils;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Date 2022/10/26
+ *
+ * @author likangli
+ * description xss攻击过滤器
+ */
+
+public class XssFilter implements Filter {
+
+	/**
+	 * 排除链接
+	 */
+	public List<String> excludes;
+
+	public XssFilter(List<String> excludes) {
+		this.excludes = excludes;
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		HttpServletRequest req = (HttpServletRequest) request;
+
+		/*
+		 * 判断是否有xss，没有直接放行；有的话处理一下。
+		 */
+		if (handleExcludeUrl(req)) {
+			chain.doFilter(request, response);
+			return;
+		}
+		XssHttpServletRequestWrapper xssRequest = new XssHttpServletRequestWrapper((HttpServletRequest) request);
+		chain.doFilter(xssRequest, response);
+	}
+
+	/**
+	 * 是否包含排除链接
+	 */
+	private boolean handleExcludeUrl(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		String method = request.getMethod();
+
+		if (method == null || HttpMethod.GET.matches(method) || HttpMethod.DELETE.matches(method)) {
+			return true;
+		}
+		if (CollectionUtils.isEmpty(excludes)) {
+			return false;
+		}
+		return excludes.contains(uri);
+	}
+
+}
+

--- a/common/common-web/src/main/java/cn/sticki/common/web/filter/XssHttpServletRequestWrapper.java
+++ b/common/common-web/src/main/java/cn/sticki/common/web/filter/XssHttpServletRequestWrapper.java
@@ -1,0 +1,40 @@
+package cn.sticki.common.web.filter;
+
+import cn.hutool.http.HTMLFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * Date 2022/10/26
+ *
+ * @author likangli
+ * description 处理xss的request包装类
+ */
+public class XssHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+	public XssHttpServletRequestWrapper(HttpServletRequest request) {
+		super(request);
+	}
+
+	@Override
+	public String[] getParameterValues(String name) {
+		String[] values = super.getParameterValues(name);
+		if (values != null) {
+			int length = values.length;
+			String[] escapeValues = new String[length];
+			for (int i = 0; i < length; i++) {
+				//防止xss攻击和过滤前后空格
+				escapeValues[i] = clean((values[i].trim()));
+			}
+			return escapeValues;
+		}
+		return super.getParameterValues(name);
+	}
+
+	private String clean(String content) {
+		return new HTMLFilter().filter(content);
+	}
+
+}
+

--- a/common/common-web/src/main/resources/META-INF/spring.factories
+++ b/common/common-web/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  cn.sticki.common.web.anno.RequestLimitAspect
+  cn.sticki.common.web.anno.RequestLimitAspect,\
+  cn.sticki.common.web.config.FilterConfig

--- a/document/mysql_config/blog.sql
+++ b/document/mysql_config/blog.sql
@@ -21,19 +21,20 @@ SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS `blog`;
 CREATE TABLE `blog`
 (
-    `id`            int(11) UNSIGNED                                              NOT NULL AUTO_INCREMENT COMMENT '博客id',
-    `author_id`     int(11) UNSIGNED                                              NOT NULL COMMENT '作者id',
+    `id`            int(11) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '博客id',
+    `author_id`     int(11) UNSIGNED NOT NULL COMMENT '作者id',
     `title`         varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '标题',
     `description`   varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '描述',
-    `school_code`   int(11) UNSIGNED                                              NULL     DEFAULT NULL COMMENT '院校代码',
-    `cover_image`   char(32) CHARACTER SET utf8 COLLATE utf8_general_mysql500_ci  NULL     DEFAULT NULL COMMENT '封面图',
+    `school_code`   int(11) UNSIGNED NULL DEFAULT NULL COMMENT '院校代码',
+    `cover_image`   char(32) CHARACTER SET utf8 COLLATE utf8_general_mysql500_ci NULL DEFAULT NULL COMMENT '封面图',
     `create_time`   datetime                                                      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-    `release_time`  datetime                                                      NULL     DEFAULT NULL COMMENT '发表时间',
-    `modified_time` datetime                                                      NULL     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
-    `status`        int(11) UNSIGNED                                              NOT NULL COMMENT '发表状态（1表示已发表、2表示未发表、3为仅自己可见、4为回收站、5为审核中）',
+    `release_time`  datetime NULL DEFAULT NULL COMMENT '发表时间',
+    `modified_time` datetime NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+    `status`        int(11) UNSIGNED NOT NULL COMMENT '发表状态（1表示已发表、2表示未发表、3为仅自己可见、4为回收站、5为审核中）',
+    `create_type`   int(11) UNSIGNED NOT NULL COMMENT '博客创作类型：1. 原创; 2. 转载',
     PRIMARY KEY (`id`) USING BTREE,
-    INDEX `author_id` (`author_id`) USING BTREE,
-    INDEX `school_code` (`school_code`) USING BTREE
+    INDEX           `author_id` (`author_id`) USING BTREE,
+    INDEX           `school_code` (`school_code`) USING BTREE
 ) ENGINE = InnoDB
   AUTO_INCREMENT = 1
   CHARACTER SET = utf8

--- a/resource-service/resource-server/src/main/java/cn/sticki/resource/pojo/University.java
+++ b/resource-service/resource-server/src/main/java/cn/sticki/resource/pojo/University.java
@@ -1,5 +1,6 @@
 package cn.sticki.resource.pojo;
 
+import com.baomidou.mybatisplus.annotation.TableField;
 import lombok.Data;
 
 /**
@@ -36,6 +37,7 @@ public class University {
 	/**
 	 * 办学层次（1本科，2专科）
 	 */
+	@TableField("`rank`")
 	Integer rank;
 
 	/**


### PR DESCRIPTION
1. 博客创作类型添加
2. 添加xss过滤器

xss过滤器暂时注释掉了，经测试，前端在展示博客内容及评论的时候，不会自动执行js脚本，不用担心js注入问题
如果要启用xss过滤器，要排除对博客添加/更新、评论添加等接口的了的过滤，可以通过XssFilter构造方法传入排除路径。
过滤器的实现方式有两种，一种是去除html标签，一种是转义html标签，当前选的去除方式，但博客的html内容，是不能去除也不能转义的，否则博客展示样式全没了。