### PR TITLE
perf(common): 优化IP限制注解，防止并发情况下等待时间不重置的问题

### DIFF
--- a/user-service/user-server/src/main/java/cn/sticki/user/controller/RegisterController.java
+++ b/user-service/user-server/src/main/java/cn/sticki/user/controller/RegisterController.java
@@ -27,7 +27,7 @@ public class RegisterController {
 
 	/**
 	 * 发送邮箱验证码请求
-	 * 90s内重复请求无效
+	 * 60s内重复请求无效
 	 *
 	 * @param mail 邮箱
 	 */

--- a/user-service/user-server/src/main/java/cn/sticki/user/service/impl/RegisterServiceImpl.java
+++ b/user-service/user-server/src/main/java/cn/sticki/user/service/impl/RegisterServiceImpl.java
@@ -77,7 +77,7 @@ public class RegisterServiceImpl extends ServiceImpl<UserSafetyMapper, UserSafet
 			return RestResult.fail("该邮箱已被注册");
 		}
 		// 4.满足条件，生成验证码
-		String code = RandomUtils.generator(6);
+		String code = RandomUtils.randomNumber(6).toString();
 		// 4.1.存入redis
 		stringRedisTemplate.opsForValue().set(key, code, REGISTER_MAIL_CODE_TTL, TimeUnit.SECONDS);
 		// 5.发送邮件


### PR DESCRIPTION
优化：
[perf(common): 优化IP限制注解，防止并发情况下等待时间不重置的问题](https://github.com/stick-i/scblogs/commit/0b46cae1fd13099f74cb17ef433a6198cfda43b2)
顺带：
[perf(user): 将注册验证码从字母改成了纯数字，便于用户记忆](https://github.com/stick-i/scblogs/commit/415c3ffff23d71ff1725e6f25d2e5c2a00e4dba9)