### PR TITLE
fix: 升级snakeyaml版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
 		<elasticsearch.version>7.12.1</elasticsearch.version>
 		<jetbrains.version>23.0.0</jetbrains.version>
 
+		<!-- Dependency org.yaml:snakeyaml [0,1.31), leading to CVE problem -->
+		<snakeyaml.version>1.31</snakeyaml.version>
 		<dockerfile-maven-plugin.version>1.3.6</dockerfile-maven-plugin.version>
 	</properties>
 


### PR DESCRIPTION
由于snakeyaml[0,1.31)会导致容易受到DoS攻击，故升级